### PR TITLE
feat: implement S-3 stats dashboard — Phase D (#5)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Navigation from './components/Navigation';
 import { useBooks } from './hooks/useBooks';
 import BookListPage from './pages/BookListPage';
 import BookDetailPage from './pages/BookDetailPage';
+import StatsDashboardPage from './pages/StatsDashboardPage';
 
 export default function App() {
   const { books, loading, error } = useBooks();
@@ -56,7 +57,11 @@ export default function App() {
           />
         )}
         {activePage === 'stats' && (
-          <p className="text-gray-400 text-sm">統計ダッシュボード（Phase D で実装）</p>
+          <StatsDashboardPage
+            books={books}
+            onFilterByGenre={handleFilterByGenre}
+            onFilterByAuthor={handleFilterByAuthor}
+          />
         )}
       </main>
 

--- a/src/components/AuthorRanking.jsx
+++ b/src/components/AuthorRanking.jsx
@@ -1,0 +1,37 @@
+import AuthorRankingRow from './AuthorRankingRow';
+
+/**
+ * AuthorRanking — top-N authors by book count
+ * Props: authorStats ([{ author, bookCount, mainGenre }]), onSelectAuthor
+ */
+export default function AuthorRanking({ authorStats, onSelectAuthor }) {
+  return (
+    <div>
+      <h2 className="text-lg font-semibold text-gray-800 mb-3">著者別ランキング（上位20名）</h2>
+      <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="bg-gray-50 border-b border-gray-200">
+              <th className="py-2 px-3 text-xs font-medium text-gray-500 text-right w-10">順位</th>
+              <th className="py-2 px-3 text-xs font-medium text-gray-500 text-left">著者名</th>
+              <th className="py-2 px-3 text-xs font-medium text-gray-500 text-right w-16">冊数</th>
+              <th className="py-2 px-3 text-xs font-medium text-gray-500 text-left">代表ジャンル</th>
+            </tr>
+          </thead>
+          <tbody>
+            {authorStats.map(({ author, bookCount, mainGenre }, index) => (
+              <AuthorRankingRow
+                key={author}
+                rank={index + 1}
+                author={author}
+                bookCount={bookCount}
+                mainGenre={mainGenre}
+                onSelect={onSelectAuthor}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AuthorRankingRow.jsx
+++ b/src/components/AuthorRankingRow.jsx
@@ -1,0 +1,21 @@
+/**
+ * AuthorRankingRow — single row in the author ranking table
+ * Props: rank, author, bookCount, mainGenre, onSelect
+ */
+export default function AuthorRankingRow({ rank, author, bookCount, mainGenre, onSelect }) {
+  return (
+    <tr className="border-b border-gray-100 hover:bg-gray-50 transition-colors">
+      <td className="py-2 px-3 text-sm text-gray-500 w-10 text-right">{rank}</td>
+      <td className="py-2 px-3">
+        <button
+          className="text-sm font-medium text-blue-600 hover:text-blue-800 hover:underline text-left"
+          onClick={() => onSelect(author)}
+        >
+          {author}
+        </button>
+      </td>
+      <td className="py-2 px-3 text-sm text-gray-700 text-right w-16">{bookCount}冊</td>
+      <td className="py-2 px-3 text-sm text-gray-500">{mainGenre}</td>
+    </tr>
+  );
+}

--- a/src/components/GenreChart.jsx
+++ b/src/components/GenreChart.jsx
@@ -1,0 +1,72 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+  ResponsiveContainer,
+} from 'recharts';
+
+const BAR_COLOR = '#3b82f6';
+const BAR_HOVER_COLOR = '#1d4ed8';
+
+/**
+ * GenreChart — horizontal bar chart of book count per genre
+ * Props: genreStats ({ [genre]: count }), onSelectGenre (genre: string) => void
+ */
+export default function GenreChart({ genreStats, onSelectGenre }) {
+  const data = Object.entries(genreStats)
+    .map(([genre, count]) => ({ genre, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const total = data.reduce((sum, d) => sum + d.count, 0);
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold text-gray-800 mb-3">ジャンル別統計</h2>
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <ResponsiveContainer width="100%" height={320}>
+          <BarChart
+            data={data}
+            layout="vertical"
+            margin={{ top: 0, right: 60, left: 10, bottom: 0 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+            <XAxis type="number" tick={{ fontSize: 12 }} />
+            <YAxis
+              type="category"
+              dataKey="genre"
+              width={130}
+              tick={{ fontSize: 12 }}
+            />
+            <Tooltip
+              formatter={(value) => [`${value}冊 (${((value / total) * 100).toFixed(1)}%)`, '冊数']}
+              cursor={{ fill: '#f3f4f6' }}
+            />
+            <Bar
+              dataKey="count"
+              radius={[0, 4, 4, 0]}
+              cursor="pointer"
+              onClick={(entry) => onSelectGenre(entry.genre)}
+              label={{ position: 'right', fontSize: 11, fill: '#6b7280', formatter: (v) => `${v}冊` }}
+            >
+              {data.map((entry) => (
+                <Cell
+                  key={entry.genre}
+                  fill={BAR_COLOR}
+                  onMouseEnter={(e) => { e.target.setAttribute('fill', BAR_HOVER_COLOR); }}
+                  onMouseLeave={(e) => { e.target.setAttribute('fill', BAR_COLOR); }}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+        <p className="text-xs text-gray-400 mt-2 text-center">
+          クリックすると書籍一覧をそのジャンルで絞り込みます
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/StatsDashboardPage.jsx
+++ b/src/pages/StatsDashboardPage.jsx
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import GenreChart from '../components/GenreChart';
+import AuthorRanking from '../components/AuthorRanking';
+import { calcGenreStats, calcAuthorRanking } from '../utils/stats';
+
+/**
+ * S-3 統計ダッシュボード
+ * Props:
+ *   books           — all books
+ *   onFilterByGenre — (genre: string) => void
+ *   onFilterByAuthor — (author: string) => void
+ */
+export default function StatsDashboardPage({ books, onFilterByGenre, onFilterByAuthor }) {
+  const genreStats = useMemo(() => calcGenreStats(books), [books]);
+  const authorStats = useMemo(() => calcAuthorRanking(books, 20), [books]);
+
+  return (
+    <div className="space-y-8">
+      <GenreChart genreStats={genreStats} onSelectGenre={onFilterByGenre} />
+      <AuthorRanking authorStats={authorStats} onSelectAuthor={onFilterByAuthor} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- F-12 ジャンル別統計: recharts の横棒グラフでジャンル別冊数を表示。クリックで S-1 書籍一覧へジャンルフィルタ適用
- F-13 著者別ランキング: 上位20名を冊数順にテーブル表示（順位・著者名・冊数・代表ジャンル）。著者名クリックで S-1 著者絞り込み
- `StatsDashboardPage` で stats.js の `calcGenreStats` / `calcAuthorRanking` を useMemo で計算
- `App.jsx` のプレースホルダを `StatsDashboardPage` に差し替え

Closes #5

## Test plan

- [x] 統計タブに切り替えるとジャンル別棒グラフが表示される
- [x] グラフのバーをクリックすると書籍一覧タブに切り替わりジャンルフィルタが適用される
- [x] 著者ランキングに上位20名が冊数降順で表示される
- [x] 著者名をクリックすると書籍一覧タブに切り替わり著者絞り込みが適用される
- [ ] `npm run build` がエラーなく完了する

🤖 Generated with [Claude Code](https://claude.com/claude-code)