### PR TITLE
docs: fix generate-ai-comments run and .env setup steps (#54)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,11 @@ npm install
 # Generate books.json from CSV (data processing pipeline)
 node scripts/process.js
 
-# Generate AI recommendation comments for daily suggestion (requires GEMINI_API_KEY)
-node scripts/generate-ai-comments.js              # diff mode: ungenerated books only
-node scripts/generate-ai-comments.js --days 30    # prioritize next 30 days' featured books
-node scripts/generate-ai-comments.js --all        # regenerate all books
+# Generate AI recommendation comments for daily suggestion
+# Always use the shell wrapper: it injects GEMINI_API_KEY from 1Password via `op run`.
+bash scripts/generate-ai-comments.sh              # diff mode: ungenerated books only
+bash scripts/generate-ai-comments.sh --days 30    # prioritize next 30 days' featured books
+bash scripts/generate-ai-comments.sh --all        # regenerate all books
 
 # Start development server
 npm run dev
@@ -64,9 +65,11 @@ npm run build
 
 - Input data: `data/booklist.csv` (exported from Google Drive via Google Apps Script)
 - Generated catalog: `data/books.json` (do not edit manually; regenerate via `process.js`)
-- AI comments: `data/book-ai-comments.json` (do not edit manually; regenerate via `generate-ai-comments.js`)
+- AI comments: `data/book-ai-comments.json` (do not edit manually; regenerate via `generate-ai-comments.sh`)
 - No backend server — all runtime logic runs in the browser
-- `GEMINI_API_KEY` env var required for `generate-ai-comments.js`; see `docs/dev/gemini-api-setup.md`
+- `GEMINI_API_KEY` is required by `generate-ai-comments.js`, but never set it by hand: `.env` holds a
+  1Password reference (`op://API/gemini_booklist/...`) and `scripts/generate-ai-comments.sh` resolves it
+  via `op run`. Always invoke the `.sh` wrapper. See `docs/dev/gemini-api-setup.md`
 
 ## Project Workflow Settings
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -44,8 +44,8 @@ data/kindle-books.json            ─┘
   data/kindle-list.csv ──→ node scripts/parse-kindle-list.js
 
 data/books.json ──→ node scripts/enrich.js ──→ data/book-metadata.json
-data/books.json ──→ node scripts/generate-ai-comments.js ──→ data/book-ai-comments.json
-                   (要 GEMINI_API_KEY)
+data/books.json ──→ bash scripts/generate-ai-comments.sh ──→ data/book-ai-comments.json
+                   (GEMINI_API_KEY は 1Password から op run で注入)
 ```
 
 ### 補助データファイル

--- a/docs/app/architecture.md
+++ b/docs/app/architecture.md
@@ -45,7 +45,7 @@ data/book-metadata.json              ← Git管理対象
 
 data/books.json
 data/book-metadata.json
-  └─ node scripts/generate-ai-comments.js  ← 手動実行（GEMINI_API_KEY 必要）
+  └─ bash scripts/generate-ai-comments.sh  ← 手動実行（1Password 経由で GEMINI_API_KEY を注入）
         │  ・Gemini APIでおすすめコメントを生成
         │  ・差分生成（未生成IDのみ対象、--days N / --all オプションあり）
         │  ・無料枠リミット到達時は中断・途中保存

--- a/docs/app/spec/system/data-pipeline.md
+++ b/docs/app/spec/system/data-pipeline.md
@@ -389,19 +389,20 @@ if (isbn !== null) {
 
 ```bash
 # 差分生成（デフォルト: コメント未生成の書籍のみ）
-node scripts/generate-ai-comments.js
+bash scripts/generate-ai-comments.sh
 
 # 今日から N 日後までの日替わり対象書籍を優先して生成
-node scripts/generate-ai-comments.js --days 30
+bash scripts/generate-ai-comments.sh --days 30
 
 # 全書籍のコメントを再生成
-node scripts/generate-ai-comments.js --all
+bash scripts/generate-ai-comments.sh --all
 ```
 
 **前提条件**:
 - `data/books.json` が存在すること
 - `data/book-metadata.json` が存在すること（存在しない場合はあらすじなしでプロンプト送信）
-- 環境変数 `GEMINI_API_KEY` が設定されていること
+- 環境変数 `GEMINI_API_KEY` が設定されていること。値は `.env` の 1Password 参照（`op://API/gemini_booklist/...`）を
+  `scripts/generate-ai-comments.sh` が `op run` で解決して注入するため、`op` にサインイン済みであること
 
 ### パイプライン
 

--- a/docs/dev/gemini-api-setup.md
+++ b/docs/dev/gemini-api-setup.md
@@ -19,15 +19,25 @@ This guide explains how to obtain a Gemini API key and configure it for generati
 
 ---
 
-## 2. Configure the API Key
+## 2. Store the API Key in 1Password
 
-Add the key to `.env` in the project root:
+The key is **not** written into `.env` directly. It is stored in 1Password and injected at runtime by
+`scripts/generate-ai-comments.sh` via `op run`.
+
+1. Save the key in 1Password as item `gemini_booklist` in the `API` vault
+   (these names must match `secretsVault` / `secretsItems` in `.claude/workflow.json`)
+2. Point `.env` in the project root at that item using a secret reference:
 
 ```
-GEMINI_API_KEY=your_api_key_here
+GEMINI_API_KEY=op://API/gemini_booklist/<field-name>
 ```
 
-`.env` is listed in `.gitignore` and will not be committed to the repository.
+> ⚠️ Do **not** paste the literal API key into `.env`. Doing so overwrites the reference, breaks the
+> `op run` wrapper, and leaves the key in plaintext on disk.
+
+`.env` is listed in `.gitignore` and will not be committed to the repository. Because it holds only a
+reference — not the key itself — the 1Password CLI (`op`) must be installed and signed in before
+running the script.
 
 ---
 
@@ -44,7 +54,7 @@ npm install @google/generative-ai
 Run a small test to confirm the key is working:
 
 ```bash
-node scripts/generate-ai-comments.js --days 7
+bash scripts/generate-ai-comments.sh --days 7
 ```
 
 Expected output (example):
@@ -76,10 +86,10 @@ To generate comments for all books (~882 books), run the script across multiple 
 
 ```bash
 # Day 1: generate up to the daily limit
-node scripts/generate-ai-comments.js
+bash scripts/generate-ai-comments.sh
 
 # Day 2: resume (already-generated books are skipped automatically)
-node scripts/generate-ai-comments.js
+bash scripts/generate-ai-comments.sh
 ```
 
 ---
@@ -90,10 +100,10 @@ Generate comments for upcoming daily suggestions first, then fill in the rest:
 
 ```bash
 # Generate comments for the next 30 days' featured books
-node scripts/generate-ai-comments.js --days 30
+bash scripts/generate-ai-comments.sh --days 30
 
 # Gradually fill in remaining books
-node scripts/generate-ai-comments.js
+bash scripts/generate-ai-comments.sh
 ```
 
 ---

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -85,5 +85,5 @@ Open `http://localhost:5173` (or the port shown in terminal) and confirm the boo
 | `npm test` | Run tests |
 | `npm run lint` | Run linter |
 | `node scripts/process.js` | Regenerate `data/books.json` from `data/booklist.csv` |
-| `node scripts/generate-ai-comments.js` | Generate AI recommendation comments (`data/book-ai-comments.json`) |
-| `node scripts/generate-ai-comments.js --days 30` | Generate comments for books featured in the next 30 days |
+| `bash scripts/generate-ai-comments.sh` | Generate AI recommendation comments (`data/book-ai-comments.json`); injects `GEMINI_API_KEY` via 1Password |
+| `bash scripts/generate-ai-comments.sh --days 30` | Generate comments for books featured in the next 30 days |


### PR DESCRIPTION
> ⚠️ **Phase precondition overridden (`--force`)**
> Skipped phases: Phase 1: 設計書作成完了, Phase 2: 開発者承認, Phase 3: 仕様書更新完了
> Reason: ドキュメント記載のみの修正で、変更内容が Issue #54 本文に完全に仕様化されているため（対象ファイル・行・あるべき形・完了条件を明示）。設計書を要する設計判断が無いと判断した。

## 概要

`scripts/generate-ai-comments.sh`（1Password CLI ラッパー）を追加したコミット `715d24f` 以降、運用ドキュメントの記載が更新されずに残っていた問題を修正する。記載どおり実行すると `GEMINI_API_KEY` が注入されず失敗する状態だった。

## 関連 Issue
- Closes #54

## 設計書
- なし（`--force` により Phase 1 をスキップ。仕様は Issue #54 本文に記載）

## 仕様書更新範囲
- `docs/app/spec/system/data-pipeline.md`（Phase 3 としてではなく本 PR 内で同時修正）

## 変更内容

### 1. `.env` の設定手順を実態に合わせて修正（影響度：最大）

`docs/dev/gemini-api-setup.md` の「2. Configure the API Key」は `.env` に **API キーを直接書く**よう指示していたが、実際の `.env` に入っているのは 1Password のシークレット参照（`op://API/gemini_booklist/...`）。手順どおりに実行すると参照が実キーで上書きされ、ラッパーの仕組みが壊れ、かつ API キーが平文でディスクに残っていた。

「1Password の `API` vault に `gemini_booklist` として保存し、`.env` には `op://` 参照を書く」手順に書き換え、実キーを書かないよう警告を追加した。参照名は `.claude/workflow.json` の `secretsVault` / `secretsItems` と一致している。

### 2. 実行コマンドを `.sh` ラッパー経由に統一（12 箇所）

| ファイル | 箇所 |
|---|---|
| `CLAUDE.md` | 3 |
| `docs/dev/gemini-api-setup.md` | 5 |
| `docs/dev/setup.md` | 2 |
| `docs/app/spec/system/data-pipeline.md` | 3 |
| `docs/app/architecture.md` | 1 |
| `PROJECT_STATE.md` | 1 |

ラッパーは `op run --env-file=.env -- node scripts/generate-ai-comments.js "$@"` で引数を透過するため、`--days N` / `--all` の説明文はそのまま維持している。

### 3. 前提条件の記述を補足

`data-pipeline.md` の前提条件に「`op` にサインイン済みであること」を追記した。

## スコープ外（意図的に対象外とした項目）

- **`docs/app/design/` 配下の設計書（11 ファイル）** — 各 Issue 時点の決定を記録した履歴文書のため、当時の記載を後から書き換えない
- **`process.js` の不要な `op run` ラップ** — `CLAUDE.md:82` と `.claude/workflow.json` の `dataUpdateCommand` が `op run --env-file=.env -- node scripts/process.js` になっているが、`process.js` は `process.env` を一切参照しておらず 1Password ラップは不要。性質が異なるため別 Issue とする

## テスト

- `npm test` ✅ 256 tests / 25 suites all pass（fail 0）
- `npm run lint` ⚠️ 未通過（プロジェクト固有の問題・本変更とは無関係）: `.claude/workflow.json` と `CLAUDE.md` は `lintCommand` に `npm run lint` を定義しているが、`package.json` に `lint` スクリプトが存在せず `npm ERR! Missing script: "lint"` となる。別 Issue で対応。
- 残存チェック（Issue 完了条件）✅ 設計書を除く全 Markdown で `node scripts/generate-ai-comments` の残存 **0 件**

```
$ grep -rn "node scripts/generate-ai-comments" --include=*.md . \
    | grep -v node_modules | grep -v "^./docs/app/design/" | wc -l
0
```

## Test plan

- [ ] `op` にサインインした状態で `bash scripts/generate-ai-comments.sh --days 7` が成功すること
- [ ] `docs/dev/gemini-api-setup.md` の手順を初見で追って、`.env` に実キーを書かずセットアップできること
- [ ] `docs/dev/deploy_user_guidance.md:70` の既存記載（`./scripts/generate-ai-comments.sh`）と形式が矛盾しないこと
